### PR TITLE
Rysteboe new hooks

### DIFF
--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/AbstractMultiParentHook.java
@@ -55,7 +55,7 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
             firstRun = false;
 
             // Change the "download"" directory; after download, it's simply used for reference
-            File childPath = new File(config.workDirectory.getAbsolutePath() + "/" + getParentFolder() + "/" + currentPlugin.name);
+            File childPath = new File(config.workDirectory.getAbsolutePath() + "/" + getParentFolder() + "/" + getPluginFolderName(currentPlugin));
 
             System.out.println("Child path for " + currentPlugin.getDisplayName() + " " + childPath);
             moreInfo.put("checkoutDir", childPath);
@@ -80,4 +80,11 @@ public abstract class AbstractMultiParentHook extends PluginCompatTesterHookBefo
      */
     protected abstract String getParentProjectName();
 
+    /**
+     * Returns the plugin folder name, by default it will be the plugin name, but can be overriden to support plugins
+     * (like structs) that are not located in a folder with the same name than the plugin itself
+     */
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
+        return currentPlugin.name;
+    }
 }

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/MultiParentCompileHook.java
@@ -45,9 +45,10 @@ public class MultiParentCompileHook extends PluginCompatTesterHookBeforeCompile 
             mavenConfig = getMavenConfig(config);
 
             File pluginDir = (File) moreInfo.get("pluginDir");
-            Path pluginSourcesDir = config.getLocalCheckoutDir().toPath();
+            System.out.print("Plugin dir is " + pluginDir);
 
-            if (pluginSourcesDir != null) {
+            if (config.getLocalCheckoutDir() != null) {
+                Path pluginSourcesDir = config.getLocalCheckoutDir().toPath();
                 boolean isMultipleLocalPlugins = config.getIncludePlugins() != null && config.getIncludePlugins().size() > 1;
                 // We are running for local changes, let's copy the .eslintrc file if we can
                 // If we are using localCheckoutDir with multiple plugins the .eslintrc must be located at the top level

--- a/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/StructsHook.java
+++ b/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/StructsHook.java
@@ -1,5 +1,6 @@
 package org.jenkins.tools.test.hook;
 
+import hudson.model.UpdateSite;
 import org.jenkins.tools.test.model.PomData;
 
 import java.util.Map;
@@ -8,7 +9,7 @@ public class StructsHook extends AbstractMultiParentHook {
 
     @Override
     protected String getParentFolder() {
-        return "";
+        return "structs-plugin";
     }
 
     @Override
@@ -24,6 +25,11 @@ public class StructsHook extends AbstractMultiParentHook {
     @Override
     public boolean check(Map<String, Object> info) throws Exception {
         return isStructsPlugin(info);
+    }
+
+    @Override
+    protected String getPluginFolderName(UpdateSite.Plugin currentPlugin) {
+        return "plugin";
     }
 
     public static boolean isStructsPlugin(Map<String, Object> moreInfo) {


### PR DESCRIPTION
Just to show you some of the changes you need, your hook was failing for two reasons:
* A bug in MultiparentCompileHook that was causing a NPE when not using a localCheckoutDir
* Hooks where not able to test plugins whose home folder where different than the plugin name

This changes solve that, now even with this changes this is going to fail because PCT is changing the parent of the plugin to point to jenkins standard plugin parent, the culprit is https://github.com/jenkinsci/plugin-compat-tester/blob/master/plugins-compat-tester/src/main/java/org/jenkins/tools/test/hook/TransformPom.java

To solve this you need to make sure that TransformPom is not applied to `structs` plugin (ideally to any plugin whose parent is not the standard jenkins one) and probably make sure `structs`plugin parent is using the latest jenkins parent pom if needed